### PR TITLE
add session_id to object example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This will return an object with some information about each session:
 ```php
 [
   {
+    "session_id": "2MM6ECkJuUr78mmtA5aPldXSVEfTmOjnSigeP0tg",
     "device": {
       "browser": "Safari",
       "desktop": true,


### PR DESCRIPTION
Modify the object example to show the optional session_id as per pull request #17 

Apologies, missed this in the original PR.