### PR TITLE
logoutOtherDevices error when calling from a API issues fix

### DIFF
--- a/config/browser-sessions.php
+++ b/config/browser-sessions.php
@@ -2,4 +2,5 @@
 
 return [
     'include_session_id' => false,
+    'browser_session_guard' => env('BROWSER_SESSION_GUARD', 'web'),
 ];

--- a/src/BrowserSessions.php
+++ b/src/BrowserSessions.php
@@ -65,7 +65,7 @@ class BrowserSessions
             ]);
         }
 
-        Auth::guard()->logoutOtherDevices($password);
+        Auth::guard(config(key: 'browser-sessions.browser_session_guard'))->logoutOtherDevices($password);
 
         $this->deleteOtherSessionRecords();
     }


### PR DESCRIPTION
[Bug]: logoutOtherDevices error when calling from a API #20  fixed

I've added authentication guard options to the browser-sessions.php configuration file. Anyone who wants to use a custom guard can now set it via the BROWSER_SESSION_GUARD environment variable. The default value is set to web.

@cjmellor , please review this and let me know if any changes are needed—I'm happy to make adjustments!