### PR TITLE
feat: add Laravel 13 support and drop EOL Laravel 10/11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/cjmellor/browser-sessions?color=rgb%2856%20189%20248%29&label=release&style=for-the-badge)](https://packagist.org/packages/cjmellor/browser-sessions)
 [![Total Downloads](https://img.shields.io/packagist/dt/cjmellor/browser-sessions.svg?color=rgb%28249%20115%2022%29&style=for-the-badge)](https://packagist.org/packages/cjmellor/browser-sessions)
 ![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/cjmellor/browser-sessions/php?color=rgb%28165%20180%20252%29&logo=php&logoColor=rgb%28165%20180%20252%29&style=for-the-badge)
-![Laravel Version](https://img.shields.io/badge/laravel-^10-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)
+![Laravel Version](https://img.shields.io/badge/laravel-^12|^13-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)
 
 > [!WARNING]
 >

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^12.0|^13.0",
         "jenssegers/agent": "^2.6",
         "spatie/laravel-package-tools": "^1.14"
     },
     "require-dev": {
-        "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^10.0|^11.5.3",
-        "pestphp/pest": "^2.0|^3.7",
-        "pestphp/pest-plugin-arch": "^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.1",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3",
+        "pestphp/pest": "^3.7",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.1",
         "laravel/pint": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
- Require illuminate/support ^12.0|^13.0 (drops Laravel 10 and 11)
- Update orchestra/testbench to ^10.0|^11.0 (adds testbench for Laravel 13)
- Drop nunomaduro/collision ^7.0 constraint (Laravel 10 era)
- Drop phpunit/phpunit ^10.0 and pestphp/* ^2.0 constraints (no longer needed)

Closes #37